### PR TITLE
CI: run Android unit tests via GitHub Actions so agent PRs can go green

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -1,0 +1,49 @@
+name: android-tests
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: gradle
+
+      - name: Install Android SDK and deps
+        env:
+          ANDROID_SDK_ROOT: ${{ github.workspace }}/.android-sdk
+          ANDROID_HOME: ${{ github.workspace }}/.android-sdk
+        run: |
+          set -euxo pipefail
+
+          mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+          curl -sSL https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -o /tmp/cmdline.zip
+          unzip -q /tmp/cmdline.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
+          mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+          export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$PATH"
+
+          yes | sdkmanager --licenses >/dev/null
+
+          # Detect compileSdk (Kotlin or Groovy DSL)
+          COMPILE_SDK=$(grep -RhoE 'compileSdk\s*=\s*[0-9]+' --include=build.gradle.kts . | grep -oE '[0-9]+' | head -n1 || true)
+          if [ -z "$COMPILE_SDK" ]; then
+            COMPILE_SDK=$(grep -RhoE 'compileSdk(VERSION)?\s*[0-9]+' --include=build.gradle . | grep -oE '[0-9]+' | head -n1 || true)
+          fi
+          if [ -z "$COMPILE_SDK" ]; then COMPILE_SDK=34; fi
+
+          # Detect buildToolsVersion if declared
+          BUILD_TOOLS=$(grep -RhoE 'buildToolsVersion\s*["'\''][0-9.]+' --include=build.gradle --include=build.gradle.kts . | grep -oE '[0-9.]+' | head -n1 || true)
+          if [ -z "$BUILD_TOOLS" ]; then BUILD_TOOLS="${COMPILE_SDK}.0.0"; fi
+
+          echo "Using compileSdk=$COMPILE_SDK buildTools=$BUILD_TOOLS"
+
+          sdkmanager "platform-tools" "platforms;android-${COMPILE_SDK}" "build-tools;${BUILD_TOOLS}"
+
+      - name: Run unit tests
+        run: ./gradlew --no-daemon --console=plain test

--- a/README.md
+++ b/README.md
@@ -19,5 +19,9 @@ You can find released APKs [here](https://github.com/crackededed/Xtra/releases/t
 
 [Xtra subreddit](https://www.reddit.com/r/XtraForTwitch)
 
+## CI
+
+The GitHub Actions workflow `android-tests / unit` runs on each push and pull request and should be configured as a required status check in branch protection.
+
 ## License
 Xtra is licensed under the [GNU Affero General Public License v3.0](LICENSE).


### PR DESCRIPTION
## Summary
- add an android-tests workflow that prepares the Android SDK based on the detected compileSdk/buildTools and runs `./gradlew test`
- document the new workflow and note it should be a required status check

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68c90a51dfd8832788154806670ed5a4