### PR TITLE
Handle sdkmanager license acceptance exit code

### DIFF
--- a/.github/workflows/android-tests.yml
+++ b/.github/workflows/android-tests.yml
@@ -28,7 +28,7 @@ jobs:
           mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
           export PATH="$ANDROID_SDK_ROOT/cmdline-tools/latest/bin:$ANDROID_SDK_ROOT/platform-tools:$PATH"
 
-          yes | sdkmanager --licenses >/dev/null
+          yes | sdkmanager --licenses >/dev/null || true
 
           # Detect compileSdk (Kotlin or Groovy DSL)
           COMPILE_SDK=$(grep -RhoE 'compileSdk\s*=\s*[0-9]+' --include=build.gradle.kts . | grep -oE '[0-9]+' | head -n1 || true)


### PR DESCRIPTION
## Summary
- update the Android SDK installation step to tolerate `yes` exiting early when accepting licenses

## Testing
- not run (workflow rerun requires GitHub Actions access)


------
https://chatgpt.com/codex/tasks/task_b_68c98fd77db083279f06fc85b9ff0dca