### PR TITLE
Add background Kick token refresh worker

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/XtraApp.kt
@@ -19,6 +19,7 @@ import coil3.network.NetworkResponse
 import coil3.network.NetworkResponseBody
 import coil3.network.okhttp.OkHttpNetworkFetcherFactory
 import coil3.util.DebugLogger
+import com.github.andreyasadchy.xtra.kick.auth.KickTokenRefreshScheduler
 import com.github.andreyasadchy.xtra.util.C
 import com.github.andreyasadchy.xtra.util.HttpEngineUtils
 import com.github.andreyasadchy.xtra.util.coil.CacheControlCacheStrategy
@@ -49,6 +50,7 @@ class XtraApp : Application(), Configuration.Provider, SingletonImageLoader.Fact
     override fun onCreate() {
         super.onCreate()
         INSTANCE = this
+        kickTokenRefreshScheduler.schedule()
     }
 
     @Inject
@@ -72,6 +74,9 @@ class XtraApp : Application(), Configuration.Provider, SingletonImageLoader.Fact
 
     @Inject
     lateinit var okHttpClient: OkHttpClient
+
+    @Inject
+    lateinit var kickTokenRefreshScheduler: KickTokenRefreshScheduler
 
     @OptIn(ExperimentalCoilApi::class)
     override fun newImageLoader(context: PlatformContext): ImageLoader {

--- a/app/src/main/java/com/github/andreyasadchy/xtra/kick/auth/KickTokenRefreshScheduler.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/kick/auth/KickTokenRefreshScheduler.kt
@@ -1,0 +1,55 @@
+package com.github.andreyasadchy.xtra.kick.auth
+
+import android.content.Context
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.github.andreyasadchy.xtra.kick.storage.KickTokenProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class KickTokenRefreshScheduler @Inject constructor(
+    @ApplicationContext private val applicationContext: Context,
+    private val tokenProvider: KickTokenProvider,
+) {
+
+    fun schedule(delayOverrideMillis: Long? = null) {
+        val refreshToken = tokenProvider.refreshToken
+        if (refreshToken.isNullOrBlank()) {
+            WorkManager.getInstance(applicationContext)
+                .cancelUniqueWork(KickTokenRefreshWorker.UNIQUE_WORK_NAME)
+            return
+        }
+
+        val delayMillis = computeDelayMillis(delayOverrideMillis)
+        val request = OneTimeWorkRequestBuilder<KickTokenRefreshWorker>()
+            .setInitialDelay(delayMillis, TimeUnit.MILLISECONDS)
+            .addTag(KickTokenRefreshWorker.UNIQUE_WORK_NAME)
+            .build()
+        WorkManager.getInstance(applicationContext).enqueueUniqueWork(
+            KickTokenRefreshWorker.UNIQUE_WORK_NAME,
+            ExistingWorkPolicy.REPLACE,
+            request
+        )
+    }
+
+    fun cancel() {
+        WorkManager.getInstance(applicationContext)
+            .cancelUniqueWork(KickTokenRefreshWorker.UNIQUE_WORK_NAME)
+    }
+
+    private fun computeDelayMillis(delayOverrideMillis: Long?): Long {
+        val baseDelay = delayOverrideMillis ?: tokenProvider.expiresAtMillis?.let { expiresAt ->
+            expiresAt - System.currentTimeMillis() - GRACE_PERIOD_MILLIS
+        } ?: DEFAULT_DELAY_MILLIS
+        return baseDelay.coerceAtLeast(0L)
+    }
+
+    companion object {
+        private const val GRACE_PERIOD_MILLIS = 60_000L
+        private val DEFAULT_DELAY_MILLIS = TimeUnit.HOURS.toMillis(1)
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/kick/auth/KickTokenRefreshWorker.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/kick/auth/KickTokenRefreshWorker.kt
@@ -1,0 +1,50 @@
+package com.github.andreyasadchy.xtra.kick.auth
+
+import android.content.Context
+import android.util.Log
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.WorkerParameters
+import com.github.andreyasadchy.xtra.kick.storage.KickTokenProvider
+import com.github.andreyasadchy.xtra.kick.storage.KickTokenStore
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+
+@HiltWorker
+class KickTokenRefreshWorker @AssistedInject constructor(
+    @Assisted appContext: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val kickOAuthClient: KickOAuthClient,
+    private val tokenStore: KickTokenStore,
+    private val tokenProvider: KickTokenProvider,
+    private val scheduler: KickTokenRefreshScheduler,
+) : CoroutineWorker(appContext, workerParams) {
+
+    override suspend fun doWork(): Result {
+        val refreshToken = tokenProvider.refreshToken
+        if (refreshToken.isNullOrBlank()) {
+            scheduler.cancel()
+            return Result.success()
+        }
+
+        if (!tokenProvider.isAccessTokenExpired()) {
+            scheduler.schedule()
+            return Result.success()
+        }
+
+        return try {
+            val response = kickOAuthClient.refreshToken(refreshToken)
+            tokenStore.update(response)
+            scheduler.schedule()
+            Result.success()
+        } catch (t: Throwable) {
+            Log.w(TAG, "Failed to refresh Kick OAuth token", t)
+            Result.retry()
+        }
+    }
+
+    companion object {
+        const val UNIQUE_WORK_NAME = "kick_token_refresh"
+        private const val TAG = "KickRefreshWorker"
+    }
+}

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
@@ -23,6 +23,7 @@ import androidx.webkit.WebViewFeature
 import com.github.andreyasadchy.xtra.R
 import com.github.andreyasadchy.xtra.databinding.ActivityLoginBinding
 import com.github.andreyasadchy.xtra.kick.auth.KickOAuthClient
+import com.github.andreyasadchy.xtra.kick.auth.KickTokenRefreshScheduler
 import com.github.andreyasadchy.xtra.kick.config.KickEnvironment
 import com.github.andreyasadchy.xtra.kick.storage.KickTokenStore
 import com.github.andreyasadchy.xtra.util.applyTheme
@@ -49,6 +50,9 @@ class LoginActivity : AppCompatActivity() {
 
     @Inject
     lateinit var environment: KickEnvironment
+
+    @Inject
+    lateinit var kickTokenRefreshScheduler: KickTokenRefreshScheduler
 
     private lateinit var binding: ActivityLoginBinding
 
@@ -210,6 +214,7 @@ class LoginActivity : AppCompatActivity() {
                     kickOAuthClient.exchangeAuthorizationCode(code, verifier)
                 }
                 kickTokenStore.update(response)
+                kickTokenRefreshScheduler.schedule()
                 setResult(RESULT_OK)
                 finish()
             } catch (t: Throwable) {


### PR DESCRIPTION
## Summary
- add a dedicated WorkManager scheduler for refreshing Kick OAuth tokens
- implement a Hilt-enabled worker that checks token expiry and refreshes when needed
- hook the scheduler into app startup and login completion so future refreshes are enqueued

## Testing
- ./gradlew :app:compileDebugKotlin *(fails: missing Android SDK in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c9933188348327b9ef85623fb116a6