### PR TITLE
Fix release build Kotlin errors

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/bttv/KickBttvModels.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/bttv/KickBttvModels.kt
@@ -48,7 +48,7 @@ data class KickBttvImageSet(
 /**
  * Identifiers accepted by BetterTTV for channel level queries.
  */
-sealed class KickBttvIdentifier internal constructor(
+sealed class KickBttvIdentifier protected constructor(
     internal val segments: List<String>
 ) {
     class KickChannelSlug(slug: String) : KickBttvIdentifier(listOf("kick", slug))

--- a/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/ui/login/LoginActivity.kt
@@ -101,10 +101,12 @@ class LoginActivity : AppCompatActivity() {
             javaScriptEnabled = true
             domStorageEnabled = true
             userAgentString = userAgentString + " XtraKick/Android"
-            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK) && !isLightTheme()) {
-                WebSettingsCompat.setForceDark(this, WebSettingsCompat.FORCE_DARK_ON)
-            } else if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK) && isLightTheme()) {
-                WebSettingsCompat.setForceDark(this, WebSettingsCompat.FORCE_DARK_OFF)
+            if (WebViewFeature.isFeatureSupported(WebViewFeature.FORCE_DARK)) {
+                if (this@LoginActivity.isLightTheme) {
+                    WebSettingsCompat.setForceDark(this, WebSettingsCompat.FORCE_DARK_OFF)
+                } else {
+                    WebSettingsCompat.setForceDark(this, WebSettingsCompat.FORCE_DARK_ON)
+                }
             }
         }
         webView.webChromeClient = object : WebChromeClient() {


### PR DESCRIPTION
## Summary
- mark the KickBttvIdentifier base class constructor as protected to satisfy Kotlin's sealed class visibility requirements
- reference the Context.isLightTheme extension property when configuring the login WebView's dark mode handling

## Testing
- ./gradlew --console=plain assembleRelease

------
https://chatgpt.com/codex/tasks/task_b_68c9900f67ac8327b50dd3f2ec9bface