### PR TITLE
feat: map kick chat events to typed models

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/KickChatModels.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/KickChatModels.kt
@@ -1,0 +1,155 @@
+package com.github.andreyasadchy.xtra.kick.chat
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+/**
+ * Representation of the events emitted by Kick's chat websocket.
+ */
+sealed interface KickChatEvent {
+    val envelope: KickChatEnvelope
+
+    /**
+     * A standard chat message.
+     */
+    data class ChatMessage(
+        override val envelope: KickChatEnvelope,
+        val message: KickChatMessage
+    ) : KickChatEvent
+
+    /**
+     * Any event that is currently not mapped to a strongly typed model.
+     */
+    data class Unknown(override val envelope: KickChatEnvelope) : KickChatEvent
+}
+
+/**
+ * Chat message as delivered by Kick.
+ */
+@Serializable
+data class KickChatMessage(
+    val id: String,
+    @SerialName("chatroom_id") val chatroomId: Long,
+    val content: String,
+    val type: String,
+    @SerialName("created_at") val createdAt: String,
+    val sender: KickChatSender,
+    val metadata: KickChatMetadata? = null
+) {
+    val badges: List<KickChatBadge>
+        get() = sender.identity?.badges.orEmpty()
+
+    val emotes: List<KickChatEmote>
+        get() = metadata?.emotes.orEmpty()
+
+    val reply: KickChatReply?
+        get() = metadata?.replyOrNull
+}
+
+@Serializable
+data class KickChatSender(
+    val id: Long,
+    val username: String,
+    val slug: String? = null,
+    val identity: KickChatIdentity? = null
+)
+
+@Serializable
+data class KickChatIdentity(
+    val color: String? = null,
+    val badges: List<KickChatBadge> = emptyList()
+)
+
+@Serializable
+data class KickChatBadge(
+    val type: String,
+    val text: String? = null,
+    val count: Int? = null,
+    val source: String? = null,
+    val image: KickChatBadgeImage? = null,
+    @SerialName("badge_image") val badgeImage: KickChatBadgeImage? = null
+) {
+    val artwork: KickChatBadgeImage?
+        get() = image ?: badgeImage
+}
+
+@Serializable
+data class KickChatBadgeImage(
+    val src: String? = null,
+    val srcset: String? = null,
+    @SerialName("src_set") val srcSet: String? = null
+)
+
+@Serializable
+data class KickChatMetadata(
+    val badges: List<KickChatBadge>? = null,
+    val emotes: List<KickChatEmote>? = null,
+    val reply: KickChatReply? = null,
+    @SerialName("original_message") val originalMessage: KickChatMetadataMessage? = null,
+    @SerialName("original_sender") val originalSender: KickChatMetadataSender? = null
+) {
+    val replyOrNull: KickChatReply?
+        get() = reply ?: originalMessage?.let { message ->
+            KickChatReply(
+                id = message.id,
+                userId = originalSender?.id,
+                username = originalSender?.username,
+                displayName = originalSender?.displayName,
+                message = message.content
+            )
+        }
+}
+
+@Serializable
+data class KickChatMetadataMessage(
+    val id: String? = null,
+    val content: String? = null
+)
+
+@Serializable
+data class KickChatMetadataSender(
+    val id: Long? = null,
+    val username: String? = null,
+    @SerialName("display_name") val displayName: String? = null,
+    val slug: String? = null
+)
+
+@Serializable
+data class KickChatEmote(
+    val id: String? = null,
+    val name: String? = null,
+    val type: String? = null,
+    val source: String? = null,
+    val code: String? = null,
+    val url: String? = null,
+    val slug: String? = null,
+    val image: KickChatEmoteImage? = null,
+    val channel: KickChatEmoteChannel? = null
+)
+
+@Serializable
+data class KickChatEmoteImage(
+    val src: String? = null,
+    val srcset: String? = null,
+    @SerialName("src_set") val srcSet: String? = null
+)
+
+@Serializable
+data class KickChatEmoteChannel(
+    val id: Long? = null,
+    val name: String? = null,
+    val slug: String? = null
+)
+
+@Serializable
+data class KickChatReply(
+    val id: String? = null,
+    @SerialName("user_id") val userId: Long? = null,
+    val username: String? = null,
+    @SerialName("display_name") val displayName: String? = null,
+    @SerialName("message") val message: String? = null,
+    val content: String? = null
+) {
+    val text: String?
+        get() = message ?: content
+}

--- a/app/src/test/java/com/github/andreyasadchy/xtra/kick/chat/KickChatClientTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/kick/chat/KickChatClientTest.kt
@@ -54,10 +54,10 @@ class KickChatClientTest {
             })
         )
 
-        val events = mutableListOf<KickChatEnvelope>()
+        val events = mutableListOf<KickChatEvent>()
         val listener = object : KickChatClient.Listener {
             override fun onConnected() {}
-            override fun onMessage(message: KickChatEnvelope) { events.add(message) }
+            override fun onMessage(event: KickChatEvent) { events.add(event) }
             override fun onClosed(code: Int, reason: String) {}
             override fun onError(throwable: Throwable) {}
         }


### PR DESCRIPTION
## Summary
- add serializable models for Kick chat events, messages, badges, emotes, and replies
- update the chat client to convert websocket envelopes into typed events before notifying listeners
- adjust the Kick chat client test to use the new listener contract

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68c99631f8c08327865795bd61f8157a