### PR TITLE
Fix BetterTTV image scaling

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/bttv/KickBttvService.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/bttv/KickBttvService.kt
@@ -87,8 +87,8 @@ class KickBttvService @Inject constructor(
         return KickBttvImageSet(
             url1x = "https://cdn.betterttv.net/emote/$emoteId/$suffix1x",
             url2x = "https://cdn.betterttv.net/emote/$emoteId/$suffix2x",
-            url3x = "https://cdn.betterttv.net/emote/$emoteId/$suffix2x",
-            url4x = "https://cdn.betterttv.net/emote/$emoteId/$suffix3x",
+            url3x = "https://cdn.betterttv.net/emote/$emoteId/$suffix3x",
+            url4x = null,
         )
     }
 

--- a/app/src/test/java/com/github/andreyasadchy/xtra/kick/chat/bttv/KickBttvServiceTest.kt
+++ b/app/src/test/java/com/github/andreyasadchy/xtra/kick/chat/bttv/KickBttvServiceTest.kt
@@ -8,6 +8,7 @@ import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -51,6 +52,9 @@ class KickBttvServiceTest {
         assertTrue(emote.isOverlay)
         assertTrue(emote.isAnimated)
         assertEquals("https://cdn.betterttv.net/emote/abc123/1x", emote.images.url1x)
+        assertEquals("https://cdn.betterttv.net/emote/abc123/2x", emote.images.url2x)
+        assertEquals("https://cdn.betterttv.net/emote/abc123/3x", emote.images.url3x)
+        assertNull(emote.images.url4x)
         assertEquals("/3/cached/emotes/global", mockWebServer.takeRequest().path)
     }
 
@@ -78,9 +82,14 @@ class KickBttvServiceTest {
         assertEquals("Hello", hello.name)
         assertFalse(hello.isAnimated)
         assertEquals("https://cdn.betterttv.net/emote/def456/1x.webp", hello.images.url1x)
+        assertEquals("https://cdn.betterttv.net/emote/def456/2x.webp", hello.images.url2x)
+        assertEquals("https://cdn.betterttv.net/emote/def456/3x.webp", hello.images.url3x)
+        assertNull(hello.images.url4x)
         assertEquals("World", world.name)
         assertTrue(world.isAnimated)
         assertEquals("https://cdn.betterttv.net/emote/ghi789/2x.webp", world.images.url2x)
+        assertEquals("https://cdn.betterttv.net/emote/ghi789/3x.webp", world.images.url3x)
+        assertNull(world.images.url4x)
 
         val firstRequest = mockWebServer.takeRequest()
         val secondRequest = mockWebServer.takeRequest()


### PR DESCRIPTION
## Summary
- fix BetterTTV image construction to use the correct 3x suffix and drop the unused 4x variant
- extend KickBttvService tests to cover all image scale URLs for both webp and png payloads

## Testing
- ./gradlew testDebugUnitTest *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c99fbfb3e88327935a4ac94b5e138e