### PR TITLE
Update Android workflow to install SDK components

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -19,6 +19,21 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+    - name: Install Android SDK components
+      run: |
+        ANDROID_SDK_ROOT="$HOME/android-sdk"
+        ANDROID_HOME="$ANDROID_SDK_ROOT"
+        mkdir -p "$ANDROID_SDK_ROOT/cmdline-tools"
+        curl -sSL https://dl.google.com/android/repository/commandlinetools-linux-11076708_latest.zip -o /tmp/cmdline-tools.zip
+        unzip -q /tmp/cmdline-tools.zip -d "$ANDROID_SDK_ROOT/cmdline-tools"
+        rm -rf "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+        mv "$ANDROID_SDK_ROOT/cmdline-tools/cmdline-tools" "$ANDROID_SDK_ROOT/cmdline-tools/latest"
+        rm /tmp/cmdline-tools.zip
+        echo "ANDROID_SDK_ROOT=$ANDROID_SDK_ROOT" >> $GITHUB_ENV
+        echo "ANDROID_HOME=$ANDROID_HOME" >> $GITHUB_ENV
+        export ANDROID_SDK_ROOT ANDROID_HOME
+        yes | "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" --licenses || true
+        "$ANDROID_SDK_ROOT/cmdline-tools/latest/bin/sdkmanager" --sdk_root="$ANDROID_SDK_ROOT" --install "platforms;android-36" "build-tools;36.0.0"
     - name: Build with Gradle
       run: ./gradlew assembleRelease
 


### PR DESCRIPTION
## Summary
- install the Android command line tools during CI and accept the SDK licenses safely
- download platform 36 and build-tools 36.0.0 while exporting ANDROID_HOME/ANDROID_SDK_ROOT for later steps

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_b_68c99fc10c088327add17c502433b9fa