### PR TITLE
Integrate Kick chat client in chat view model

### DIFF
--- a/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/KickChatEnvelope.kt
+++ b/app/src/main/java/com/github/andreyasadchy/xtra/kick/chat/KickChatEnvelope.kt
@@ -27,5 +27,19 @@ data class KickChatEnvelope(
                 ref = UUID.randomUUID().toString()
             )
         }
+
+        fun chatMessage(channelId: Long, content: String, replyParentId: String? = null): KickChatEnvelope {
+            return KickChatEnvelope(
+                event = "message",
+                topic = "chatrooms:$channelId",
+                payload = buildJsonObject {
+                    put("chatroom_id", channelId)
+                    put("content", content)
+                    put("type", if (replyParentId != null) "reply" else "message")
+                    replyParentId?.let { put("reply_to", it) }
+                },
+                ref = UUID.randomUUID().toString()
+            )
+        }
     }
 }


### PR DESCRIPTION
## Summary
- inject KickChatClient into ChatViewModel and replace legacy IRC/websocket fields
- rework live chat lifecycle to connect/disconnect via KickChatClient, handle Phoenix events, and map messages to ChatMessage
- support outgoing chat by building KickChatEnvelope payloads and sending them through the Kick client

## Testing
- ./gradlew testDebugUnitTest *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_b_68cd6dbe9c788327a71c4e1b612af7d6